### PR TITLE
Fix ansible ImportError: cannot import name IncompleteRead

### DIFF
--- a/playbooks/roles/cacher/tasks/main.yml
+++ b/playbooks/roles/cacher/tasks/main.yml
@@ -24,6 +24,10 @@
   command: chmod -x /etc/cron.daily/mlocate
   ignore_errors: yes
 
+- name: update PIP
+  command: easy_install -U pip
+  ignore_errors: yes
+
 - name: updating the system
   apt: update_cache=yes
 

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -26,6 +26,10 @@
   command: chmod -x /etc/cron.daily/mlocate
   ignore_errors: yes
 
+- name: update PIP
+  command: easy_install -U pip
+  ignore_errors: yes
+
 - name: set local proxy config
   template: src=01proxy.j2 dest=/etc/apt/apt.conf.d/01proxy owner=root group=root mode=644
   when: CACHE.pkg_cache == "create"  or  CACHE.pkg_cache == "use"


### PR DESCRIPTION
Ansible task fails on Ubuntu 14.04 because of pip dependencies
Fix: http://stackoverflow.com/questions/27341064/how-do-i-fix-importerror-cannot-import-name-incompleteread

> TASK: [cacher | install devpi PIP cache] **************************************
> failed: [apt-pip-cache] => {"cmd": "/usr/bin/pip install devpi-server", "failed": true}
> msg:
> :stderr: Traceback (most recent call last):
>   File "/usr/bin/pip", line 9, in <module>
>     load_entry_point('pip==1.5.4', 'console_scripts', 'pip')()
